### PR TITLE
refactor : post Entity Opinions 양방향 연관관계 삭제 (#167)

### DIFF
--- a/src/main/java/gladiator/philosopher/common/entity/PageRequest.java
+++ b/src/main/java/gladiator/philosopher/common/entity/PageRequest.java
@@ -1,0 +1,20 @@
+package gladiator.philosopher.common.entity;
+
+public class PageRequest {
+
+  private int page = 1;
+  private int size = 10;
+
+
+  public void setPage(int page){
+    this.page=page<=0?1:page;
+  }
+  public void setSize(int size){
+    int DEFAULT_SIZE= 10;
+    int MAX_SIZE =20;
+    this.size = size>MAX_SIZE?DEFAULT_SIZE:size;
+  }
+  public org.springframework.data.domain.PageRequest of(){
+    return org.springframework.data.domain.PageRequest.of(page-1,size);
+  }
+}

--- a/src/main/java/gladiator/philosopher/common/util/InitData.java
+++ b/src/main/java/gladiator/philosopher/common/util/InitData.java
@@ -131,44 +131,44 @@ public class InitData implements ApplicationRunner {
     categoryRepository.save(category5);
 
     // 게시글 부
-    Post post1 = new Post(account1, " 깻잎 논쟁 보고만 있나요? ", "김지환, 박정수", null, category1);
+    Post post1 = new Post(account1, " 깻잎 논쟁 보고만 있나요? ", "김지환, 박정수",  category1);
     postRepository.save(post1);
 
-    Post post2 = new Post(account2, " 닭이 먼저인가요 치킨이 먼저인가요 ", "박정수, 박건하", null, category1);
+    Post post2 = new Post(account2, " 닭이 먼저인가요 치킨이 먼저인가요 ", "박정수, 박건하",  category1);
     postRepository.save(post2);
 
-    Post post3 = new Post(account3, " 아 배고프다 ", "박건하, 이정국", null, category2);
+    Post post3 = new Post(account3, " 아 배고프다 ", "박건하, 이정국", category2);
     postRepository.save(post3);
 
-    Post post4 = new Post(account4, " 5억년 버튼 누르실 건가여? ", "이정국 ,이진호", null, category2);
+    Post post4 = new Post(account4, " 5억년 버튼 누르실 건가여? ", "이정국 ,이진호", category2);
     postRepository.save(post4);
 
-    Post post5 = new Post(account4, " 원더걸스 vs 뉴진스 ", "이진호, 이명박", null, category4);
+    Post post5 = new Post(account4, " 원더걸스 vs 뉴진스 ", "이진호, 이명박",  category4);
     postRepository.save(post5);
 
-    Post post6 = new Post(account5, " 여자친구 앞에서 이성 반찬 밀어주기 ", "이명박, 박명수", null, category5);
+    Post post6 = new Post(account5, " 여자친구 앞에서 이성 반찬 밀어주기 ", "이명박, 박명수", category5);
     postRepository.save(post6);
-    Post post7 = new Post(account6, " 팥붕 vs 슈붕 ", "이명박, 존박", null, category3);
+    Post post7 = new Post(account6, " 팥붕 vs 슈붕 ", "이명박, 존박",category3);
     postRepository.save(post7);
-    Post post8 = new Post(account7, " 길가는 사람에게 한대맞으면 5000원? ", "이명박, 박명수", null, category3);
+    Post post8 = new Post(account7, " 길가는 사람에게 한대맞으면 5000원? ", "이명박, 박명수", category3);
     postRepository.save(post8);
-    Post post9 = new Post(account8, " 1년뒤 1억 10년뒤 5억 ", " 9번 게시물의 내용입니다 ", null, category2);
+    Post post9 = new Post(account8, " 1년뒤 1억 10년뒤 5억 ", " 9번 게시물의 내용입니다 ",  category2);
     postRepository.save(post9);
-    Post post10 = new Post(account9, " 수저 세팅 ", "10번 게시물의 내용입니다", null, category5);
+    Post post10 = new Post(account9, " 수저 세팅 ", "10번 게시물의 내용입니다", category5);
     postRepository.save(post10);
-    Post post11 = new Post(account10, " 아 몰라 ", "11번 게시물의 내용입니다", null, category5);
+    Post post11 = new Post(account10, " 아 몰라 ", "11번 게시물의 내용입니다", category5);
     postRepository.save(post11);
-    Post post12 = new Post(account9, " 못참아 ", "12번 게시물의 내용입니다", null, category4);
+    Post post12 = new Post(account9, " 못참아 ", "12번 게시물의 내용입니다",  category4);
     postRepository.save(post12);
-    Post post13 = new Post(account8, " 사후세계? ", "이명박, 박명수", null, category1);
+    Post post13 = new Post(account8, " 사후세계? ", "이명박, 박명수", category1);
     postRepository.save(post13);
-    Post post14 = new Post(account7, " 메이웨더 vs 파퀴아오 ", "이명박, 박명수", null, category1);
+    Post post14 = new Post(account7, " 메이웨더 vs 파퀴아오 ", "이명박, 박명수", category1);
     postRepository.save(post14);
-    Post post15 = new Post(account6, " 안락사 ", "김지환", null, category2);
+    Post post15 = new Post(account6, " 안락사 ", "김지환", category2);
     postRepository.save(post15);
-    Post post16 = new Post(account5, " 죽음이란? ", "배고프다", null, category2);
+    Post post16 = new Post(account5, " 죽음이란? ", "배고프다",  category2);
     postRepository.save(post16);
-    Post post17 = new Post(account4, " 지옥 있나요?  ", "네 없습니다", null, category2);
+    Post post17 = new Post(account4, " 지옥 있나요?  ", "네 없습니다", category2);
     postRepository.save(post17);
 
     // 포스트 이미지

--- a/src/main/java/gladiator/philosopher/post/controller/PostController.java
+++ b/src/main/java/gladiator/philosopher/post/controller/PostController.java
@@ -3,6 +3,7 @@ package gladiator.philosopher.post.controller;
 import gladiator.philosopher.category.entity.Category;
 import gladiator.philosopher.category.service.CategoryService;
 import gladiator.philosopher.common.dto.MyPage;
+import gladiator.philosopher.common.entity.PageRequest;
 import gladiator.philosopher.common.s3.S3Uploader;
 import gladiator.philosopher.common.security.AccountDetails;
 import gladiator.philosopher.post.dto.PostModifyRequestDto;
@@ -81,14 +82,15 @@ public class PostController {
    * 게시글 검색 ( 완료 )
    *
    * @param condition
-   * @param pageable
+   * @param pageRequest
    * @return
    */
   @GetMapping
   @ResponseStatus(HttpStatus.OK)
   public MyPage<PostResponseDtoByQueryDsl> searchPost(
       final PostSearchCondition condition,
-      final Pageable pageable) {
+      final PageRequest pageRequest) {
+    Pageable pageable  = pageRequest.of();
     return postService.searchPostByCondition(condition, pageable);
   }
 
@@ -108,7 +110,6 @@ public class PostController {
     postService.deletePost(postId, accountDetails.getAccount());
 //    s3Uploader.DeleteS3Files(oldUrls, dirName);
   }
-
 
   /**
    * 게시글 수정

--- a/src/main/java/gladiator/philosopher/post/dto/PostResponseDto.java
+++ b/src/main/java/gladiator/philosopher/post/dto/PostResponseDto.java
@@ -25,7 +25,7 @@ public class PostResponseDto {
   private final List<String> opinions;
   private final String category;
 
-  public PostResponseDto(Post post, Long recommendCount, List<String> urls) {
+  public PostResponseDto(Post post, Long recommendCount, List<String> urls, List<String> options) {
     this.title = post.getTitle();
     this.content = post.getContent();
     this.recommend = recommendCount;
@@ -33,7 +33,7 @@ public class PostResponseDto {
     this.modifiedDate = post.getModifiedDate();
     this.nickname = post.getAccount().getNickname();
     this.images = urls;
-    this.opinions = post.getOpinions().stream().map(PostOpinion::getOpinion).collect(Collectors.toList());
+    this.opinions = options;
     this.category = post.getCategory().getName();
   }
 

--- a/src/main/java/gladiator/philosopher/post/dto/PostResponseDto.java
+++ b/src/main/java/gladiator/philosopher/post/dto/PostResponseDto.java
@@ -1,23 +1,16 @@
 package gladiator.philosopher.post.dto;
 
-import gladiator.philosopher.category.entity.Category;
 import gladiator.philosopher.post.entity.Post;
-import gladiator.philosopher.post.entity.PostImage;
-import gladiator.philosopher.post.entity.PostOpinion;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 public class PostResponseDto {
 
   private final String title;
   private final String content;
-  private final Long recommend;
+  private final Long recommendCount;
   private final LocalDateTime createDate;
   private final LocalDateTime modifiedDate;
   private final String nickname;
@@ -28,7 +21,7 @@ public class PostResponseDto {
   public PostResponseDto(Post post, Long recommendCount, List<String> urls, List<String> options) {
     this.title = post.getTitle();
     this.content = post.getContent();
-    this.recommend = recommendCount;
+    this.recommendCount = recommendCount;
     this.createDate = post.getCreatedDate();
     this.modifiedDate = post.getModifiedDate();
     this.nickname = post.getAccount().getNickname();

--- a/src/main/java/gladiator/philosopher/post/dto/PostResponseDto.java
+++ b/src/main/java/gladiator/philosopher/post/dto/PostResponseDto.java
@@ -1,5 +1,6 @@
 package gladiator.philosopher.post.dto;
 
+import gladiator.philosopher.common.util.TimeAdapter;
 import gladiator.philosopher.post.entity.Post;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -11,8 +12,8 @@ public class PostResponseDto {
   private final String title;
   private final String content;
   private final Long recommendCount;
-  private final LocalDateTime createDate;
-  private final LocalDateTime modifiedDate;
+  private final String createDate;
+  private final String modifiedDate;
   private final String nickname;
   private final List<String> images;
   private final List<String> opinions;
@@ -22,8 +23,8 @@ public class PostResponseDto {
     this.title = post.getTitle();
     this.content = post.getContent();
     this.recommendCount = recommendCount;
-    this.createDate = post.getCreatedDate();
-    this.modifiedDate = post.getModifiedDate();
+    this.createDate = TimeAdapter.formatToString(post.getCreatedDate());
+    this.modifiedDate = TimeAdapter.formatToString(post.getModifiedDate());
     this.nickname = post.getAccount().getNickname();
     this.images = urls;
     this.opinions = options;

--- a/src/main/java/gladiator/philosopher/post/dto/PostResponseDtoByQueryDsl.java
+++ b/src/main/java/gladiator/philosopher/post/dto/PostResponseDtoByQueryDsl.java
@@ -16,18 +16,18 @@ public class PostResponseDtoByQueryDsl {
   // account
   private String nickname;
   //recommend
-  private Long recommend; // 추천수
+  private Long recommendCount;
 
 
   public PostResponseDtoByQueryDsl(Long id, String title, String category,
       LocalDateTime createdDate,
-      PostStatus status, String nickname, Long recommend) {
+      PostStatus status, String nickname, Long recommendCount) {
     this.id = id;
     this.title = title;
     this.category = category;
     this.createdDate = createdDate;
     this.status = status;
     this.nickname = nickname;
-    this.recommend = recommend;
+    this.recommendCount = recommendCount;
   }
 }

--- a/src/main/java/gladiator/philosopher/post/dto/PostResponseDtoByQueryDsl.java
+++ b/src/main/java/gladiator/philosopher/post/dto/PostResponseDtoByQueryDsl.java
@@ -1,5 +1,6 @@
 package gladiator.philosopher.post.dto;
 
+import gladiator.philosopher.common.util.TimeAdapter;
 import gladiator.philosopher.post.enums.PostStatus;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -11,7 +12,7 @@ public class PostResponseDtoByQueryDsl {
   private Long id;
   private String title;
   private String category;
-  private LocalDateTime createdDate;
+  private String createdDate;
   private PostStatus status;
   // account
   private String nickname;
@@ -25,7 +26,7 @@ public class PostResponseDtoByQueryDsl {
     this.id = id;
     this.title = title;
     this.category = category;
-    this.createdDate = createdDate;
+    this.createdDate = TimeAdapter.formatToString(createdDate);
     this.status = status;
     this.nickname = nickname;
     this.recommendCount = recommendCount;

--- a/src/main/java/gladiator/philosopher/post/entity/Post.java
+++ b/src/main/java/gladiator/philosopher/post/entity/Post.java
@@ -40,9 +40,6 @@ public class Post extends BaseEntity {
   @Column(nullable = false)
   private String title;
 
-  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<PostOpinion> opinions = new ArrayList<>();
-
   @Column(nullable = false)
   private String content;
 
@@ -56,12 +53,11 @@ public class Post extends BaseEntity {
 
   @Builder
   public Post(Account account, String title, String content,
-      List<PostOpinion> opinions, Category category) {
+       Category category) {
     this.account = account;
     this.title = title;
     this.content = content;
     this.status = PostStatus.ACTIVE;
-    this.opinions = opinions;
     this.category = category;
     this.isThreaded = false;
   }

--- a/src/main/java/gladiator/philosopher/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/gladiator/philosopher/post/repository/PostCustomRepositoryImpl.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 @Slf4j

--- a/src/main/java/gladiator/philosopher/post/service/PostServiceImpl.java
+++ b/src/main/java/gladiator/philosopher/post/service/PostServiceImpl.java
@@ -67,7 +67,8 @@ public class PostServiceImpl implements PostService {
     Post post = getPostEntity(postId);
     final long recommendCount = postRecommendRepository.countByPost(post);
     final List<String> url = postImageRepository.getUrl(post.getId());
-    return new PostResponseDto(post, recommendCount, url);
+    final List<String> options = postOpinionRepository.getOptions(post.getId());
+    return new PostResponseDto(post, recommendCount, url, options);
   }
 
   @Override

--- a/src/test/java/gladiator/philosopher/factory/PostFactory.java
+++ b/src/test/java/gladiator/philosopher/factory/PostFactory.java
@@ -13,7 +13,6 @@ public class PostFactory {
         .title("post title1")
         .content("post content1")
         .category(CategoryFactory.createCategory1())
-        .opinions(List.of(createPostOpinion1(), createPostOpinion2(), createPostOpinion3()))
         .build();
   }
 
@@ -23,7 +22,6 @@ public class PostFactory {
         .title("post title2")
         .content("post content2")
         .category(CategoryFactory.createCategory2())
-        .opinions(List.of(createPostOpinion1(), createPostOpinion2(), createPostOpinion3()))
         .build();
   }
 


### PR DESCRIPTION
관호님의 의견을 반영해서 양방향 연관관계를 삭제했습니다.

삭제한 이유는 관호님 의견에 대해서 깊게 생각해보았고, 객체간의 관계를 떠나서 양방향 연관관계는 결국 양방향에서 서로를 조회하거나, 참조,  혹은 다양한 entity들을 join해서 데이터를 가지고 올 때, 유리한 장점이 있다고 생각했습니다. 하지만 post 에서는 현재 그렇지 못하다는 점과 물론 opnions와 post의 생애주기는 같지만, 성능적인 이슈나 서로를 참조할 이유가 없다고 판단했기에 양방향 연관관계를 제거했습니다.